### PR TITLE
change API to take iterable instead of splat

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
 // then copied from proposal-frozen-realms deep-freeze.js
 // then copied from SES/src/bundle/deepFreeze.js
 
-function makeHardener(...initialRoots) {
+function makeHardener(initialRoots) {
   const { freeze, getOwnPropertyDescriptors, getPrototypeOf } = Object;
   const { ownKeys } = Reflect;
   // Objects that we won't freeze, either because we've frozen them already,

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ const test = require('tape');
 const { makeHardener } = require('../index.js');
 
 test('makeHardener', t => {
-  const h = makeHardener(Object.prototype);
+  const h = makeHardener([Object.prototype]);
   const o = { a: {} };
   t.equal(h(o), o);
   t.ok(Object.isFrozen(o));
@@ -12,7 +12,7 @@ test('makeHardener', t => {
 
 test('do not freeze roots', t => {
   const parent = { I_AM_YOUR: 'parent' };
-  const h = makeHardener(parent, Object.prototype);
+  const h = makeHardener([parent, Object.prototype]);
   const o = { a: {} };
   Object.setPrototypeOf(o, parent);
   t.equal(h(o), o);
@@ -25,8 +25,8 @@ test('do not freeze roots', t => {
 test('complain about prototype not in roots', t => {
   const parent = { I_AM_YOUR: 'parent' };
   // at least one prototype is missing in each hardener
-  const h1 = makeHardener(Object.prototype);
-  const h2 = makeHardener(parent);
+  const h1 = makeHardener([Object.prototype]);
+  const h2 = makeHardener([parent]);
   const o = { a: {} };
   Object.setPrototypeOf(o, parent);
   t.throws(() => h1(o), TypeError);
@@ -39,7 +39,7 @@ test('complain about prototype not in roots', t => {
 });
 
 test('harden the same thing twice', t => {
-  const h = makeHardener(Object.prototype);
+  const h = makeHardener([Object.prototype]);
   const o = { a: {} };
   t.equal(h(o), o);
   t.equal(h(o), o);
@@ -49,7 +49,7 @@ test('harden the same thing twice', t => {
 });
 
 test('harden objects with cycles', t => {
-  const h = makeHardener(Object.prototype);
+  const h = makeHardener([Object.prototype]);
   const o = { a: {} };
   o.a.foo = o;
   t.equal(h(o), o);
@@ -59,7 +59,7 @@ test('harden objects with cycles', t => {
 });
 
 test('harden overlapping objects', t => {
-  const h = makeHardener(Object.prototype);
+  const h = makeHardener([Object.prototype]);
   const o1 = { a: {} };
   const o2 = { a: o1.a };
   t.equal(h(o1), o1);


### PR DESCRIPTION
So call `makeHardener([a,b])` instead of `makeHardener(a,b)`. This is more
verbose for a single-element fringe, but more obvious for a large fringe, and
gives us an opportunity to add more parameters in the future.

closes #3