### PR TITLE
Support ES6 modules and CJS

### DIFF
--- a/index-commonjs.js
+++ b/index-commonjs.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Adapted from SES/Caja - Copyright (C) 2011 Google Inc.
 // Copyright (C) 2018 Agoric
 
@@ -136,4 +138,4 @@ function makeHardener(initialFringe) {
   return harden;
 }
 
-export default makeHardener;
+module.exports = makeHardener;

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,18 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
+      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==",
+      "dev": true
+    },
     "acorn": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
@@ -2972,6 +2984,17 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.2.2.tgz",
+      "integrity": "sha512-fsn5KJcfSuejjrv8GV7kZNciElqxyzZdUq8rA3e528JsR3ccxrWwoptyUY8GGLlgMFAQMB3dZW8nWF2I1/xrZA==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*",
+        "acorn": "^6.1.0"
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "@agoric/make-hardener",
   "version": "0.0.3",
   "description": "Create a 'hardener' which freezes the API surface of a set of objects",
-  "main": "index.js",
+  "main": "index-commonjs.js",
+  "module": "index.js",
   "scripts": {
     "test": "node test/test.js",
     "pretty-fix": "prettier --write '**/*.{js,jsx}'",
     "lint": "eslint '**/*.{js,jsx}'",
     "pretty-check": "prettier --check '**/*.{js,jsx}'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint-check": "eslint '**/*.{js,jsx}'"
+    "lint-check": "eslint '**/*.{js,jsx}'",
+    "create-cjs": "rollup index.js --file index-commonjs.js --format cjs"
   },
   "repository": {
     "type": "git",
@@ -33,6 +35,7 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.3",
     "prettier": "1.16.4",
+    "rollup": "^1.2.2",
     "tape": "^4.9.2"
   },
   "lint-staged": {

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -1,0 +1,5 @@
+# To do before a new release
+
+1. Bump the version in `package.json`
+2. `npm install` to update `package-lock.json`'s version
+3. run `npm run create-cjs` to generate the updated CommonJS module.

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 const test = require('tape');
-const makeHardener = require('../index.js');
+const makeHardener = require('../index-commonjs.js');
 
 test('makeHardener', t => {
   const h = makeHardener([Object.prototype]);


### PR DESCRIPTION
This PR:

1. changes index.js to es6 module exports
2. uses rollup to create the cjs version
3. changes package.json to use main/module to differentiate