### PR TITLE
package.json: remove wrong keywords (copy/pasted from Nat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,5 @@
     "test": "test"
   },
   "keywords": [
-    "integer",
-    "int",
-    "overflow"
   ]
 }


### PR DESCRIPTION
@katelynsills is there an "official" list of keywords anywhere, or is it a folksonomy? Not sure what we should have for MakeHardener but probably not `integer overflow` :).
