### PR TITLE
tolerate fringe errors for async functions, test hardening of more values

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -40,6 +40,8 @@ Rollup is a little trickier. If we try to use rollup to bundle the tests and mak
 
 Parcel uses the ES6 module version of the test that we created and creates a new index.html and JavaScript files in `bundles/parcel`.
 
+Parcel uses babel to transpile the code into a "least-common-denominator" form which avoids features that aren't universally available in all browsers. Its definition of "universal" defaults to 99.75%, which unfortunately excludes generators (and we don't include the plugin that would be necessary to allows its polyfill to work). We reduce this setting to 50% for the integration test. Downstream applications which use Parcel would set this according to local taste, and would include whatever plugins are necessary to let the polyfills work.
+
 ### Unpkg
 
 Unpkg isn't really a bundler at all, but is a CDN. We create a browser-friendly version of the tape tests and load both the tests and a mocked version of the library provided by unpkg together on the same page to run the tests. 

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -17,6 +17,9 @@
     "build:rollup": "rollup -c scaffolding/rollup/rollup.config.test.js",
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel"
   },
+  "browserslist": [
+    "cover 50%"
+  ],
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/integration-test/test/utility/test-bundler.js
+++ b/integration-test/test/utility/test-bundler.js
@@ -36,7 +36,7 @@ const runBrowserTests = async indexFile => {
 const testBundler = (bundlerName, indexFile) => {
   test(`makeHardener works with ${bundlerName}`, t => {
     runBrowserTests(indexFile).then(({ numTests, numPass }) => {
-      t.equal(numTests, '31');
+      t.equal(numTests, '42');
       t.equal(numTests, numPass);
       t.end();
     });

--- a/src/index.js
+++ b/src/index.js
@@ -107,9 +107,22 @@ function makeHardener(initialFringe) {
       prototypes.forEach((path, p) => {
         if (!(toFreeze.has(p) || fringeSet.has(p))) {
           // all reachable properties have already been frozen by this point
-          throw new TypeError(
-            `prototype ${p} of ${path} is not already in the fringeSet`,
-          );
+          let msg;
+          try {
+            msg = `prototype ${p} of ${path} is not already in the fringeSet`;
+          } catch (e) {
+            // `${(async _=>_).__proto__}` fails in most engines
+            msg =
+              'a prototype of something is not already in the fringeset (and .toString failed)';
+            try {
+              console.log(msg);
+              console.log('the prototype:', p);
+              console.log('of something:', path);
+            } catch (_e) {
+              // console.log might be missing in restrictive SES realms
+            }
+          }
+          throw new TypeError(msg);
         }
       });
     }

--- a/test/test.js
+++ b/test/test.js
@@ -110,3 +110,19 @@ test('harden() tolerates objects with null prototypes', t => {
   t.ok(Object.isFrozen(o.a));
   t.end();
 });
+
+test('harden function', t => {
+  const h = makeHardener([Object.prototype, Function.prototype]);
+  const o = _a => 1;
+  t.equal(h(o), o);
+  t.ok(Object.isFrozen(o));
+  t.end();
+});
+
+test('harden async function', t => {
+  const h = makeHardener([Object.prototype, (async _ => _).__proto__]);
+  const o = async _a => 1;
+  t.equal(h(o), o);
+  t.ok(Object.isFrozen(o));
+  t.end();
+});


### PR DESCRIPTION
When a hardener is used on an object whose prototype is not in the fringe set, `harden()` throws and error and tries to give a message that explains where the missing prototype lived in the object graph it received. In the process, it tries to stringify the prototype object. This `.toString()` fails when the prototype object is an AsyncFunction. We change the diagnostic message to survive this error and report as much information as we can (logging something to the console, if one exists).

Also add more tests of hardening async functions, generators, and async generators.
